### PR TITLE
 bugfix : fix negative numbers are sign-extended to the high bits

### DIFF
--- a/WavReader_Java/wave/WavHeaderReader.java
+++ b/WavReader_Java/wave/WavHeaderReader.java
@@ -101,8 +101,8 @@ public class WavHeaderReader {
         if (!endian) {
             start += 3;
         }
-        return (buf[start] << 24) + (buf[start + k * 1] << 16) +
-                (buf[start + k * 2] << 8) + buf[start + k * 3];
+        return ((buf[start] & 0xFF) << 24) + ((buf[start + k * 1] & 0xFF) << 16) +
+                ((buf[start + k * 2] & 0xFF) << 8) + (buf[start + k * 3] & 0xFF);
     }
 
     /**


### PR DESCRIPTION
 bugfix : fix negative numbers are sign-extended to the high bits

when int is 16000 change it to byte array , and use your fun it will meet error the same  problem as toShort fun you should change it.